### PR TITLE
Fix losing data when CanZone.current expires on client

### DIFF
--- a/can-zone-storage.js
+++ b/can-zone-storage.js
@@ -2,8 +2,11 @@ module.exports = {
   data: {},
 
   getStore: function () {
-    var CanZone = window.CanZone || undefined;
-    return typeof CanZone === 'undefined' ? this.data : CanZone.current.data;
+    if (window.doneSsr) {
+      var CanZone = window.CanZone || undefined;
+      return typeof CanZone === 'undefined' ? this.data : CanZone.current.data;
+    }
+    return this.data;
   },
 
   setItem: function (prop, value) {

--- a/test/can-zone-storage_zone-test.js
+++ b/test/can-zone-storage_zone-test.js
@@ -5,9 +5,12 @@ var Zone = require('can-zone');
 
 QUnit.module('can-zone-storage with can-zone');
 
-QUnit.test('Works in a Zone', function (assert) {
+QUnit.test('Works in a Zone in doneSsr', function (assert) {
   var done = assert.async();
   new Zone().run(function () {
+    // Simulate being in doneSsr environment
+    window.doneSsr = true;
+
     assert.ok(CanZone.current.data.hasOwnProperty, 'CanZone.current.data is an object');
 
     var key = 'key';
@@ -25,6 +28,32 @@ QUnit.test('Works in a Zone', function (assert) {
 
     zoneStorage.removeItem(key);
     assert.equal(zoneStorage.data.hasOwnProperty(key), false, 'Data was removed from the CanZone.current.data store.');
+
+    // Clean up
+    delete window.doneSsr;
+    done();
+  });
+});
+
+QUnit.test('Stores data in local data store when outside SSR environment', function (assert) {
+  var done = assert.async();
+  new Zone().run(function () {
+    assert.ok(CanZone.current.data.hasOwnProperty, 'CanZone.current.data is an object');
+
+    var key = 'key';
+    var val = 'Write to the CanZone.current.data store!';
+    var store = zoneStorage.getStore();
+
+    assert.ok(zoneStorage.data === store, 'getStore returns the local data store.');
+
+    zoneStorage.setItem(key, val);
+    assert.equal(zoneStorage.data[key], val, 'Data was written to local data store.');
+
+    var retrievedVal = zoneStorage.getItem(key);
+    assert.equal(val, retrievedVal, 'getVal properly retrieves the setVal');
+
+    zoneStorage.removeItem(key);
+    assert.equal(zoneStorage.data.hasOwnProperty(key), false, 'Data was removed from the local data store.');
     done();
   });
 });


### PR DESCRIPTION
When the current zone is done processing, it appears that CanZone.current is disposed of, which removes any data that was written to it.  This checks for `window.doneSsr` to make sure that in an actual browser data is written to a local variable and never to CanZone.current.data.

This attempts to fix #2, but we might have to rename the project to `done-zone-storage` if we decide to merge this.